### PR TITLE
Add http.DefaultTransport to parameters on line 74 of client.go

### DIFF
--- a/getresponse/client.go
+++ b/getresponse/client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/healthimation/go-glitch/glitch"
 )
 
-//Error codes
+// Error codes
 const (
 	ErrorAPI = "ERROR_API"
 
@@ -71,7 +71,7 @@ type getResponseClient struct {
 // NewClient returns a new pushy client
 func NewClient(apiKey string, timeout time.Duration) Client {
 	return &getResponseClient{
-		c:      client.NewBaseClient(findGetResponse, "getresponse", true, timeout),
+		c:      client.NewBaseClient(findGetResponse, "getresponse", true, timeout, http.DefaultTransport),
 		apiKey: apiKey,
 	}
 }


### PR DESCRIPTION
This brings the client.go upto date with the modifications made to BaseClient signature in "github.com/healthimation/go-client/client"
Without this change the getresponse v3 functionality from libraries healthimation has contributed aren't available. Client code fails to build.